### PR TITLE
fix: error if input ckb amount while ckb balance is less than 64ckb

### DIFF
--- a/src/views/Deposit.tsx
+++ b/src/views/Deposit.tsx
@@ -257,6 +257,7 @@ export default function Deposit() {
       setIsCKBValueValidate(false);
     } else if (
       Amount.from(CKBInput, 8).gte(Amount.from(400, 8)) &&
+      Amount.from(CKBBalance).gte(6400000000) &&
       Amount.from(CKBInput, 8).lte(Amount.from(CKBBalance).minus(6400000000))
     ) {
       setIsCKBValueValidate(true);


### PR DESCRIPTION
deposit时，如果ckb 余额小于64，在ckb输入框输入大于400的值，页面会白屏。这个提交修复了这个bug