### PR TITLE
refactor: avoid using UI functionality name in model level

### DIFF
--- a/src/components/Input/CurrencyInputPanel.tsx
+++ b/src/components/Input/CurrencyInputPanel.tsx
@@ -218,7 +218,7 @@ export default function CurrencyInputPanel({
                     ) : (
                       <QuestionCircleOutlined style={{ width: 24, height: 24, marginRight: 10 }} />
                     )}
-                    <Tooltip title={!!tokenWithBalance.hover && translate(tokenWithBalance.hover)}>
+                    <Tooltip title={!!tokenWithBalance.uan && translate(tokenWithBalance.uan)}>
                       <div className="symbol-name">
                         <Text className="symbol">{tokenWithBalance.symbol}</Text>
                         <Text className="name">{tokenWithBalance.name}</Text>

--- a/src/light-godwoken/LightGodwokenV0.ts
+++ b/src/light-godwoken/LightGodwokenV0.ts
@@ -112,7 +112,7 @@ export default class DefaultLightGodwokenV0 extends DefaultLightGodwoken impleme
       map.push({
         name: token.layer2DisplayName || token.name,
         symbol: token.symbol,
-        hover: token.layer2UAN,
+        uan: token.layer2UAN,
         decimals: token.decimals,
         address: token.address,
         tokenURI: token.tokenURI,
@@ -145,7 +145,7 @@ export default class DefaultLightGodwokenV0 extends DefaultLightGodwoken impleme
       map.push({
         type: tokenL1Script,
         name: token.layer1DisplayName || token.name,
-        hover: token.layer1UAN,
+        uan: token.layer1UAN,
         symbol: token.symbol,
         decimals: token.decimals,
         tokenURI: token.tokenURI,

--- a/src/light-godwoken/LightGodwokenV1.ts
+++ b/src/light-godwoken/LightGodwokenV1.ts
@@ -121,7 +121,7 @@ export default class DefaultLightGodwokenV1 extends DefaultLightGodwoken impleme
         type: tokenL1Script,
         name: token.layer1DisplayName || token.name,
         symbol: token.symbol,
-        hover: token.layer1UAN,
+        uan: token.layer1UAN,
         decimals: token.decimals,
         tokenURI: token.tokenURI,
       });
@@ -142,7 +142,7 @@ export default class DefaultLightGodwokenV1 extends DefaultLightGodwoken impleme
         id: token.id,
         name: token.layer2DisplayName || token.name,
         symbol: token.symbol,
-        hover: token.layer2UAN,
+        uan: token.layer2UAN,
         decimals: token.decimals,
         address: token.address,
         tokenURI: token.tokenURI,

--- a/src/light-godwoken/lightGodwokenType.ts
+++ b/src/light-godwoken/lightGodwokenType.ts
@@ -16,7 +16,11 @@ export interface Token {
   tokenURI: string;
 }
 export interface TokenExtra extends Token {
-  hover?: string;
+  /**
+   * Universal Asset Notation
+   * @see https://github.com/nervosnetwork/rfcs/blob/a092218b8f3ba9b6616ff41bd56a5a75d42efaf7/rfcs/0000-universal-asset-notation/0000-universal-asset-notation.md
+   **/
+  uan?: string;
 }
 
 interface ERC20 extends TokenExtra {


### PR DESCRIPTION
motivation: Now that tokens have UAN informations, for convenience, I named the uan display name as "hover" in Token type, which smells bad.

This pr has：

 - change `hover` field in Token model to `uan`